### PR TITLE
fix(rpc-plugin): global response type

### DIFF
--- a/packages/rpc-plugin/README.md
+++ b/packages/rpc-plugin/README.md
@@ -204,15 +204,20 @@ expect(mockFetch).toHaveBeenCalledWith('http://test.com/api/v1/users/123', expec
 export class ApiClient {
 	get users() {
 		return {
-			create: async (
+			create: async <Result = User>(
 				options: RequestOptions<{ name: string; email: string }, undefined, undefined, undefined>
-			): Promise<any> => {
-				return this.request('POST', `/api/v1/users/`, options)
+			) => {
+				return this.request<Result>('POST', `/api/v1/users/`, options)
 			},
-			list: async (
+			list: async <Result = User[]>(
 				options?: RequestOptions<undefined, { page: number; limit: number }, undefined, undefined>
-			): Promise<any> => {
-				return this.request('GET', `/api/v1/users/`, options)
+			) => {
+				return this.request<Result>('GET', `/api/v1/users/`, options)
+			},
+			getById: async <Result = User>(
+				options: RequestOptions<undefined, { id: string }, undefined, undefined>
+			) => {
+				return this.request<Result>('GET', `/api/v1/users/:id`, options)
 			}
 		}
 	}

--- a/packages/rpc-plugin/README.md
+++ b/packages/rpc-plugin/README.md
@@ -80,7 +80,7 @@ The generated `client.ts` file contains everything you need:
 
 - **ApiClient class** with all your controller methods
 - **Type definitions** for requests, responses, and DTOs
-- **Utility types** like RequestOptions and ApiResponse
+- **Utility types** like RequestOptions
 - **Generated interfaces** from your controller types
 
 ## Custom Fetch Functions
@@ -206,12 +206,12 @@ export class ApiClient {
 		return {
 			create: async (
 				options: RequestOptions<{ name: string; email: string }, undefined, undefined, undefined>
-			): Promise<ApiResponse<any>> => {
+			): Promise<any> => {
 				return this.request('POST', `/api/v1/users/`, options)
 			},
 			list: async (
 				options?: RequestOptions<undefined, { page: number; limit: number }, undefined, undefined>
-			): Promise<ApiResponse<any>> => {
+			): Promise<any> => {
 				return this.request('GET', `/api/v1/users/`, options)
 			}
 		}

--- a/packages/rpc-plugin/src/index.ts
+++ b/packages/rpc-plugin/src/index.ts
@@ -4,7 +4,6 @@ export { RPCPlugin } from './rpc.plugin'
 // Export all types
 export type {
 	ApiError,
-	ApiResponse,
 	ControllerGroups,
 	ExtendedRouteInfo,
 	FetchFunction,

--- a/packages/rpc-plugin/src/services/client-generator.service.ts
+++ b/packages/rpc-plugin/src/services/client-generator.service.ts
@@ -241,13 +241,16 @@ ${this.generateControllerMethods(controllerGroups)}
 				const httpMethod = safeToString(route.method).toLowerCase()
 				const { pathParams, queryParams, bodyParams } = this.analyzeRouteParameters(route)
 
+				// Extract return type from route analysis for better type safety
+				const returnType = this.extractReturnType(route.returns)
+
 				const hasRequiredParams =
 					pathParams.length > 0 ||
 					queryParams.some((p) => p.required) ||
 					(bodyParams.length > 0 && httpMethod !== 'get')
 
 				// Generate the method signature with proper typing
-				methods += `			${methodName}: async (options${hasRequiredParams ? '' : '?'}: RequestOptions<`
+				methods += `			${methodName}: async <Result = ${returnType}>(options${hasRequiredParams ? '' : '?'}: RequestOptions<`
 
 				// Path parameters type
 				if (pathParams.length > 0) {
@@ -294,9 +297,7 @@ ${this.generateControllerMethods(controllerGroups)}
 				// Headers type - always optional for now, but could be made conditional
 				methods += 'undefined'
 
-				// Extract return type from route analysis for better type safety
-				const returnType = this.extractReturnType(route.returns)
-				methods += `>): Promise<${returnType}> => {
+				methods += `>) => {
 `
 
 				// Build the full API path using route information
@@ -311,7 +312,7 @@ ${this.generateControllerMethods(controllerGroups)}
 					}
 				}
 
-				methods += `				return this.request<${returnType}>('${httpMethod.toUpperCase()}', \`${requestPath}\`, options)
+				methods += `				return this.request<Result>('${httpMethod.toUpperCase()}', \`${requestPath}\`, options)
 `
 				methods += `			},
 `

--- a/packages/rpc-plugin/src/services/client-generator.service.ts
+++ b/packages/rpc-plugin/src/services/client-generator.service.ts
@@ -53,15 +53,6 @@ export class ClientGeneratorService {
 // ============================================================================
 
 /**
- * API Response wrapper
- */
-export interface ApiResponse<T = any> {
-	data: T
-	message?: string
-	success: boolean
-}
-
-/**
  * API Error class
  */
 export class ApiError extends Error {
@@ -173,7 +164,7 @@ export class ApiClient {
 		method: string,
 		path: string,
 		options: RequestOptions<any, any, any, any> = {}
-	): Promise<ApiResponse<T>> {
+	): Promise<T> {
 		const { params, query, body, headers = {} } = options as any
 		
 		// Build the final URL with path parameters
@@ -305,7 +296,7 @@ ${this.generateControllerMethods(controllerGroups)}
 
 				// Extract return type from route analysis for better type safety
 				const returnType = this.extractReturnType(route.returns)
-				methods += `>): Promise<ApiResponse<${returnType}>> => {
+				methods += `>): Promise<${returnType}> => {
 `
 
 				// Build the full API path using route information

--- a/packages/rpc-plugin/src/types/client.types.ts
+++ b/packages/rpc-plugin/src/types/client.types.ts
@@ -17,15 +17,6 @@ export type RequestOptions<TParams = never, TQuery = never, TBody = never, THead
 export type FetchFunction = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 /**
- * API Response wrapper
- */
-export interface ApiResponse<T = any> {
-	data: T
-	message?: string
-	success: boolean
-}
-
-/**
  * API Error class
  */
 export class ApiError extends Error {

--- a/packages/rpc-plugin/src/types/index.ts
+++ b/packages/rpc-plugin/src/types/index.ts
@@ -6,4 +6,4 @@ export type { RPCPluginOptions } from '../rpc.plugin'
 
 export type { GeneratedClientInfo, SchemaInfo } from './schema.types'
 
-export type { ApiError, ApiResponse, FetchFunction, RequestOptions } from './client.types'
+export type { ApiError, FetchFunction, RequestOptions } from './client.types'


### PR DESCRIPTION
Hi @kerimovok,

First off, thanks a bunch for the awesome work on Honest! I really appreciate how lightweight it is and how easy it is to use.

I ran into a little snag with the RPC plugin. The predefined `ApiResponse` type is hardcoded in the generated client, which doesn’t match the correct type on the controller (screenshot below of my controller and the generated client).



<img width="1475" height="300" alt="Screenshot 2026-02-26 at 11 37 39 AM" src="https://github.com/user-attachments/assets/13f7ae11-f0d8-4f6e-bc3e-a5482f50e300" />



This PR addresses that by removing `ApiResponse`, so it can be defined on app level. I also moved the client method response types to a generic, which allows users to customize the type on the client side when needed (screenshot below of the updated client).

<img width="1129" height="650" alt="image" src="https://github.com/user-attachments/assets/d6553d50-160f-4b3f-bc29-390d27d43d92" />



Let me know if there are any changes you’d like to see!

Cheers
