### PR TITLE
fix(rpc-plugin): insure request parameters types and names are correct with intersection support

### DIFF
--- a/packages/rpc-plugin/src/generators/generator-utils.ts
+++ b/packages/rpc-plugin/src/generators/generator-utils.ts
@@ -1,5 +1,4 @@
 import type { ControllerGroups, ExtendedRouteInfo } from '../types/route.types'
-import { buildFullApiPath } from '../utils/path-utils'
 import { safeToString } from '../utils/string-utils'
 
 /**
@@ -17,21 +16,4 @@ export function groupRoutesByController(routes: readonly ExtendedRouteInfo[]): C
 	}
 
 	return groups
-}
-
-/**
- * Builds a normalized request path where parameter placeholders are rewritten
- * to use parameter names inferred by analysis.
- */
-export function buildNormalizedRequestPath(route: ExtendedRouteInfo): string {
-	let requestPath = buildFullApiPath(route)
-
-	for (const parameter of route.parameters ?? []) {
-		if (parameter.decoratorType !== 'param') continue
-
-		const placeholder = `:${String(parameter.data ?? parameter.name)}`
-		requestPath = requestPath.replace(placeholder, `:${parameter.name}`)
-	}
-
-	return requestPath
 }

--- a/packages/rpc-plugin/src/generators/typescript-client.generator.ts
+++ b/packages/rpc-plugin/src/generators/typescript-client.generator.ts
@@ -4,7 +4,7 @@ import type { ControllerGroups, ExtendedRouteInfo, RouteParameter } from '../typ
 import type { RPCGenerator, RPCGeneratorContext } from '../types/generator.types'
 import type { GeneratedClientInfo, SchemaInfo } from '../types/schema.types'
 import { camelCase, safeToString } from '../utils/string-utils'
-import { buildNormalizedRequestPath, groupRoutesByController } from './generator-utils'
+import { groupRoutesByController } from './generator-utils'
 
 /**
  * Built-in generator for TypeScript RPC clients.
@@ -280,47 +280,9 @@ ${this.generateControllerMethods(controllerGroups)}
 				// Generate the method signature with proper typing
 				methods += `			${methodName}: async <Result = ${returnType}>(options${hasRequiredParams ? '' : '?'}: RequestOptions<`
 
-				// Path parameters type
-				if (pathParams.length > 0) {
-					const pathParamTypes = pathParams.map((p) => {
-						const paramName = p.name
-						const paramType = p.type || 'any'
-						return `${paramName}: ${paramType}`
-					})
-					methods += `{ ${pathParamTypes.join(', ')} }`
-				} else {
-					methods += 'undefined'
-				}
-
-				methods += ', '
-
-				// Query parameters type
-				if (queryParams.length > 0) {
-					const queryParamTypes = queryParams.map((p) => {
-						const paramName = p.name
-						const paramType = p.type || 'any'
-						return `${paramName}: ${paramType}`
-					})
-					methods += `{ ${queryParamTypes.join(', ')} }`
-				} else {
-					methods += 'undefined'
-				}
-
-				methods += ', '
-
-				// Body type
-				if (bodyParams.length > 0) {
-					const bodyParamTypes = bodyParams.map((p) => {
-						const paramType = p.type || 'any'
-						return paramType
-					})
-					// Use the first body parameter type, not 'any'
-					methods += bodyParamTypes[0] || 'any'
-				} else {
-					methods += 'undefined'
-				}
-
-				methods += ', '
+				methods += `${this.generateParameterType(pathParams)}, `
+				methods += `${this.generateParameterType(queryParams)}, `
+				methods += `${this.generateParameterType(bodyParams)}, `
 
 				// Headers type - always optional for now, but could be made conditional
 				methods += 'undefined'
@@ -328,10 +290,7 @@ ${this.generateControllerMethods(controllerGroups)}
 				methods += `>) => {
 `
 
-				// Build normalized path with stable parameter placeholders
-				const requestPath = buildNormalizedRequestPath(route)
-
-				methods += `				return this.request<Result>('${httpMethod.toUpperCase()}', \`${requestPath}\`, options)
+				methods += `				return this.request<Result>('${httpMethod.toUpperCase()}', \`${route.fullPath}\`, options)
 `
 				methods += `			},
 `
@@ -398,5 +357,33 @@ ${this.generateControllerMethods(controllerGroups)}
 			.map((p) => ({ ...p, required: p.required === true }))
 
 		return { pathParams, queryParams, bodyParams }
+	}
+
+	/**
+	 * Generate parameter typing with intersection support
+	 */
+	private generateParameterType(params: readonly RouteParameter[]): string {
+		if (!params?.length) return 'undefined'
+
+		const paramsNamed: string[] = []
+		const paramsIntersection: string[] = []
+
+		params.forEach((p) => {
+			// data is missing from @Param() type intersection
+			if (!p.data) {
+				paramsIntersection.push(p.type)
+			} else {
+				const paramName = p.data
+				const paramType = p.type || 'any'
+				paramsNamed.push(`${paramName}: ${paramType}`)
+			}
+		})
+
+		const parsedNamed = paramsNamed.length ? `{ ${paramsNamed.join(', ')} }` : undefined
+		const parsedIntersection = paramsIntersection.length ? paramsIntersection.join(' & ') : undefined
+
+		if (parsedNamed && parsedIntersection) return `${parsedIntersection} & ${parsedNamed}`
+
+		return parsedNamed || parsedIntersection || 'undefined'
 	}
 }


### PR DESCRIPTION
Hi @kerimovok,

This PR fixes couple of issues related to parameters typing, names and generated client.

For example this controller which has 2 endpoints for each parameter (params, query & body):

<img width="1072" height="1017" alt="Screenshot 2026-03-17 at 4 10 24 PM" src="https://github.com/user-attachments/assets/b02f8bb7-0645-4da1-b2c1-5ee9c0c887fb" />

<br>
<br>

which generates this client output:

<img width="1305" height="499" alt="Screenshot 2026-03-17 at 3 57 24 PM" src="https://github.com/user-attachments/assets/1bd0482e-1a87-447d-859a-2f748621f0ec" />

<br>
<br>

The generated client has a few issues:

1. parameters typed with a class are being added as nested property `nestedParams` or ignored in case of `@Body()`
2. parameters named extracted are the variable name in the controller method, not the one passed to the parameter, which leads to the client having incorrect parameters names (most obvious in query)
3. the endpoint being rewritten to support the incorrect parameter names

<br>
<br>

I've added a private method to `TypeScriptClientGenerator` to fix this behavior and reuse it for all parameters, here's a screenshot of the client generated afterwards:

<img width="1293" height="503" alt="Screenshot 2026-03-17 at 3 59 31 PM" src="https://github.com/user-attachments/assets/2aad40ab-c302-4857-bc5c-01bb8bf749a6" />

<br>
<br>

I believe also with this fix `buildNormalizedRequestPath` method is redundant so it's removed in the PR and replaced by using `fullPath` directly


Please let me know if there is any changes you like to see or if you have questions


Cheers,
Aziz