### PR TITLE
(rpc-plugin): Increase interface typing coverage

### DIFF
--- a/packages/rpc-plugin/src/generators/typescript-client.generator.test.ts
+++ b/packages/rpc-plugin/src/generators/typescript-client.generator.test.ts
@@ -183,6 +183,64 @@ describe('TypeScriptClientGenerator', () => {
 		expect(content).toContain('export interface UserDto')
 	})
 
+	it('insure deduplicated interfaces and types', async () => {
+		outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rpc-client-'))
+		const schemas: SchemaInfo[] = [
+			{
+				type: 'UserRole',
+				schema: {
+					definitions: {
+						UserRole: {
+							type: 'string',
+							enum: ['user', 'admin']
+						}
+					}
+				},
+				typescriptType: "export type UserRole = 'user' | 'admin'"
+			},
+			{
+				type: 'UserDto',
+				schema: {
+					definitions: {
+						UserDto: {
+							properties: {
+								id: { type: 'string' },
+								role: { $ref: '#/definitions/UserRole' }
+							},
+							required: ['id']
+						},
+						UserRole: {
+							type: 'string',
+							enum: ['user', 'admin']
+						}
+					}
+				},
+				typescriptType:
+					"export interface UserDto {\n  id: string\n  role: UserRole\n}\n\nexport type UserRole = 'user' | 'admin'"
+			},
+			{
+				type: 'UserDto',
+				schema: {
+					definitions: {
+						UserDto: {
+							properties: { id: { type: 'string' } },
+							required: ['id']
+						}
+					}
+				},
+				typescriptType: 'export interface UserDto {\n  id: string\n}'
+			}
+		]
+		const generator = new TypeScriptClientGenerator(outputDir)
+
+		await generator.generateClient([], schemas)
+
+		const content = fs.readFileSync(path.join(outputDir, 'client.ts'), 'utf-8')
+
+		expect(content.match(/export interface UserDto {/g)).toHaveLength(1)
+		expect(content.match(/export type UserRole =/g)).toHaveLength(1)
+	})
+
 	it('handles routes with query parameters', async () => {
 		outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rpc-client-'))
 		const route: ExtendedRouteInfo = {

--- a/packages/rpc-plugin/src/generators/typescript-client.generator.ts
+++ b/packages/rpc-plugin/src/generators/typescript-client.generator.ts
@@ -385,12 +385,29 @@ ${this.generateControllerMethods(controllerGroups)}
 			return '// No schemas available from integrated Schema Generation\n'
 		}
 
+		// dedupe declarations by type/interface name
+		const seenTypeNames = new Set<string>()
+
 		let content = '// Schema types from integrated Schema Generation\n'
+
 		for (const schemaInfo of schemas) {
-			if (schemaInfo.typescriptType) {
-				content += `${schemaInfo.typescriptType}\n\n`
+			const declarations = schemaInfo.typescriptType?.split('\n\n') || []
+			for (const declaration of declarations) {
+				const match = declaration.match(/^export\s+(?:interface|type)\s+([A-Za-z0-9_]+)/m)
+
+				if (!match) {
+					content += `${declaration}\n\n`
+					continue
+				}
+
+				const typeName = match[1]
+				if (seenTypeNames.has(typeName)) continue
+
+				seenTypeNames.add(typeName)
+				content += `${declaration}\n\n`
 			}
 		}
+
 		return content
 	}
 

--- a/packages/rpc-plugin/src/services/schema-generator.service.test.ts
+++ b/packages/rpc-plugin/src/services/schema-generator.service.test.ts
@@ -195,5 +195,40 @@ describe('SchemaGeneratorService', () => {
 			expect(onWarn).toHaveBeenCalled()
 			expect(onWarn.mock.calls[0][0]).toContain('Failed to generate schema')
 		})
+
+		it('generates interfaces and types for all definitions', async () => {
+			const { project, controllerPattern, tsConfigPath } = createTempProject({
+				'test.controller.ts': `
+					export type UserRole = 'user' | 'admin'
+
+					export interface Post {
+						id: string
+						title: string
+					}
+
+					export interface UserDto {
+						id: string
+						role: UserRole
+						posts: Post[]
+					}
+
+					class TestController {
+						findAll(): UserDto[] {
+							return []
+						}
+					}
+				`
+			})
+
+			const service = new SchemaGeneratorService(controllerPattern, tsConfigPath)
+			const result = await service.generateSchemas(project)
+
+			expect(result.length).toBeGreaterThanOrEqual(1)
+			const userSchema = result.find((s) => s.type === 'UserDto')
+			expect(userSchema).toBeDefined()
+			expect(userSchema!.typescriptType).toMatch(
+				"export interface UserDto {\n\tid: string\n\trole: UserRole\n\tposts: Post[]\n}\n\nexport type UserRole = 'user' | 'admin'\n\nexport interface Post {\n\tid: string\n\ttitle: string\n}"
+			)
+		})
 	})
 })

--- a/packages/rpc-plugin/src/services/schema-generator.service.ts
+++ b/packages/rpc-plugin/src/services/schema-generator.service.ts
@@ -100,8 +100,13 @@ export class SchemaGeneratorService {
 				const definitionsKeys = Object.keys(schema?.definitions || {}) || []
 				const types: string[] = []
 
-				for (const definitionKey of definitionsKeys) {
-					types.push(generateTypeScriptInterface(definitionKey, schema))
+				// fallback when schema has no definitions
+				if (definitionsKeys.length === 0) {
+					types.push(generateTypeScriptInterface(typeName, schema))
+				} else {
+					for (const definitionKey of definitionsKeys) {
+						types.push(generateTypeScriptInterface(definitionKey, schema))
+					}
 				}
 
 				schemas.push({

--- a/packages/rpc-plugin/src/services/schema-generator.service.ts
+++ b/packages/rpc-plugin/src/services/schema-generator.service.ts
@@ -97,12 +97,17 @@ export class SchemaGeneratorService {
 		for (const typeName of collectedTypes) {
 			try {
 				const schema = await this.generateSchemaForType(typeName)
-				const typescriptType = generateTypeScriptInterface(typeName, schema)
+				const definitionsKeys = Object.keys(schema?.definitions || {}) || []
+				const types: string[] = []
+
+				for (const definitionKey of definitionsKeys) {
+					types.push(generateTypeScriptInterface(definitionKey, schema))
+				}
 
 				schemas.push({
 					type: typeName,
 					schema,
-					typescriptType
+					typescriptType: types.join('\n\n')
 				})
 			} catch (err) {
 				if (this.failOnSchemaError) {

--- a/packages/rpc-plugin/src/utils/schema-utils.test.ts
+++ b/packages/rpc-plugin/src/utils/schema-utils.test.ts
@@ -36,7 +36,7 @@ describe('schema-utils', () => {
 					required: ['id'],
 					additionalProperties: false
 				})
-			).toBe('{\n\tid: number\n\tname?: string\n}')
+			).toBe('{\n\t\tid: number\n\t\tname?: string\n\t}')
 		})
 
 		it('returns any for unknown or missing type', () => {

--- a/packages/rpc-plugin/src/utils/schema-utils.test.ts
+++ b/packages/rpc-plugin/src/utils/schema-utils.test.ts
@@ -39,6 +39,54 @@ describe('schema-utils', () => {
 			).toBe('{\n\t\tid: number\n\t\tname?: string\n\t}')
 		})
 
+		it('maps dictionary object type from additionalProperties schema', () => {
+			expect(
+				mapJsonSchemaTypeToTypeScript({
+					type: 'object',
+					additionalProperties: { type: 'string' }
+				})
+			).toBe('Record<string, string>')
+		})
+
+		it('maps dictionary object type from additionalProperties=true', () => {
+			expect(
+				mapJsonSchemaTypeToTypeScript({
+					type: 'object',
+					additionalProperties: true
+				})
+			).toBe('Record<string, unknown>')
+		})
+
+		it('maps object with known properties and additionalProperties', () => {
+			expect(
+				mapJsonSchemaTypeToTypeScript({
+					type: 'object',
+					properties: {
+						id: { type: 'number' }
+					},
+					required: ['id'],
+					additionalProperties: { type: 'string' }
+				})
+			).toBe('{\n\t\tid: number\n\t} & Record<string, string>')
+		})
+
+		it('maps empty object schema to open dictionary when additionalProperties is omitted', () => {
+			expect(
+				mapJsonSchemaTypeToTypeScript({
+					type: 'object'
+				})
+			).toBe('Record<string, unknown>')
+		})
+
+		it('maps additionalProperties=false with no properties to Record<string, never>', () => {
+			expect(
+				mapJsonSchemaTypeToTypeScript({
+					type: 'object',
+					additionalProperties: false
+				})
+			).toBe('Record<string, never>')
+		})
+
 		it('returns any for unknown or missing type', () => {
 			expect(mapJsonSchemaTypeToTypeScript({})).toBe('any')
 			expect(mapJsonSchemaTypeToTypeScript({ type: 'unknown' })).toBe('any')

--- a/packages/rpc-plugin/src/utils/schema-utils.test.ts
+++ b/packages/rpc-plugin/src/utils/schema-utils.test.ts
@@ -26,7 +26,17 @@ describe('schema-utils', () => {
 		})
 
 		it('maps object type', () => {
-			expect(mapJsonSchemaTypeToTypeScript({ type: 'object' })).toBe('Record<string, any>')
+			expect(
+				mapJsonSchemaTypeToTypeScript({
+					type: 'object',
+					properties: {
+						id: { type: 'number' },
+						name: { type: 'string' }
+					},
+					required: ['id'],
+					additionalProperties: false
+				})
+			).toBe('{\n\tid: number\n\tname?: string\n}')
 		})
 
 		it('returns any for unknown or missing type', () => {

--- a/packages/rpc-plugin/src/utils/schema-utils.ts
+++ b/packages/rpc-plugin/src/utils/schema-utils.ts
@@ -45,23 +45,30 @@ export function generateTypeScriptInterface(typeName: string, schema: Record<str
 			return `export type ${typeName} = ${union}`
 		}
 
-		const properties = typeDefinition.properties || {}
-		const required = typeDefinition.required || []
-
 		let interfaceCode = `export interface ${typeName} {\n`
 
-		for (const [propName, propSchema] of Object.entries(properties)) {
-			const isRequired = required.includes(propName)
-			const type = mapJsonSchemaTypeToTypeScript(propSchema as Record<string, any>)
-			const optional = isRequired ? '' : '?'
-
-			interfaceCode += `\t${propName}${optional}: ${type}\n`
-		}
-
+		interfaceCode += generateTypeScriptInterfaceProperties(typeDefinition)
 		interfaceCode += '}'
 		return interfaceCode
 	} catch (error) {
 		console.error(`Failed to generate TypeScript interface for ${typeName}:`, error)
 		return `export interface ${typeName} {\n\t// Failed to generate interface\n}`
 	}
+}
+
+export function generateTypeScriptInterfaceProperties(schema: Record<string, any>): string {
+	const properties = schema.properties || {}
+	const required = schema.required || []
+
+	let interfaceCode = ''
+
+	for (const [propName, propSchema] of Object.entries(properties)) {
+		const isRequired = required.includes(propName)
+		const type = mapJsonSchemaTypeToTypeScript(propSchema as Record<string, any>)
+		const optional = isRequired ? '' : '?'
+
+		interfaceCode += `\t${propName}${optional}: ${type}\n`
+	}
+
+	return interfaceCode
 }

--- a/packages/rpc-plugin/src/utils/schema-utils.ts
+++ b/packages/rpc-plugin/src/utils/schema-utils.ts
@@ -19,8 +19,28 @@ export function mapJsonSchemaTypeToTypeScript(schema: Record<string, any>, inden
 			const itemType = mapJsonSchemaTypeToTypeScript(schema.items || {}, indentation)
 			return `${itemType}[]`
 		}
-		case 'object':
-			return `{\n${generateTypeScriptInterfaceProperties(schema, `${indentation}\t`)}${indentation}}`
+		case 'object': {
+			const hasProperties = Object.keys(schema.properties || {}).length > 0
+			const objectLiteral = `{\n${generateTypeScriptInterfaceProperties(schema, `${indentation}\t`)}${indentation}}`
+			const additional = schema.additionalProperties
+
+			// Keep open object semantics for map/dictionary schemas.
+			if (additional !== undefined && additional !== false) {
+				const additionalType =
+					additional === true
+						? 'unknown'
+						: mapJsonSchemaTypeToTypeScript(additional as Record<string, any>, indentation)
+				const recordType = `Record<string, ${additionalType}>`
+				return hasProperties ? `${objectLiteral} & ${recordType}` : recordType
+			}
+
+			if (additional === false) {
+				return hasProperties ? objectLiteral : 'Record<string, never>'
+			}
+
+			// additionalProperties omitted: treat empty object as open dictionary.
+			return hasProperties ? objectLiteral : 'Record<string, unknown>'
+		}
 		default:
 			if (schema?.$ref) {
 				return schema?.$ref.replace('#/definitions/', '')

--- a/packages/rpc-plugin/src/utils/schema-utils.ts
+++ b/packages/rpc-plugin/src/utils/schema-utils.ts
@@ -20,7 +20,7 @@ export function mapJsonSchemaTypeToTypeScript(schema: Record<string, any>): stri
 			return `${itemType}[]`
 		}
 		case 'object':
-			return 'Record<string, any>'
+			return `{\n${generateTypeScriptInterfaceProperties(schema)}}`
 		default:
 			return 'any'
 	}

--- a/packages/rpc-plugin/src/utils/schema-utils.ts
+++ b/packages/rpc-plugin/src/utils/schema-utils.ts
@@ -1,7 +1,7 @@
 /**
  * Maps JSON schema types to TypeScript types
  */
-export function mapJsonSchemaTypeToTypeScript(schema: Record<string, any>): string {
+export function mapJsonSchemaTypeToTypeScript(schema: Record<string, any>, indentation = '\t'): string {
 	const type = schema.type as string
 
 	switch (type) {
@@ -16,11 +16,11 @@ export function mapJsonSchemaTypeToTypeScript(schema: Record<string, any>): stri
 		case 'boolean':
 			return 'boolean'
 		case 'array': {
-			const itemType = mapJsonSchemaTypeToTypeScript(schema.items || {})
+			const itemType = mapJsonSchemaTypeToTypeScript(schema.items || {}, indentation)
 			return `${itemType}[]`
 		}
 		case 'object':
-			return `{\n${generateTypeScriptInterfaceProperties(schema)}}`
+			return `{\n${generateTypeScriptInterfaceProperties(schema, `${indentation}\t`)}${indentation}}`
 		default:
 			if (schema?.$ref) {
 				return schema?.$ref.replace('#/definitions/', '')
@@ -59,7 +59,7 @@ export function generateTypeScriptInterface(typeName: string, schema: Record<str
 	}
 }
 
-export function generateTypeScriptInterfaceProperties(schema: Record<string, any>): string {
+export function generateTypeScriptInterfaceProperties(schema: Record<string, any>, indentation = '\t'): string {
 	const properties = schema.properties || {}
 	const required = schema.required || []
 
@@ -67,10 +67,10 @@ export function generateTypeScriptInterfaceProperties(schema: Record<string, any
 
 	for (const [propName, propSchema] of Object.entries(properties)) {
 		const isRequired = required.includes(propName)
-		const type = mapJsonSchemaTypeToTypeScript(propSchema as Record<string, any>)
+		const type = mapJsonSchemaTypeToTypeScript(propSchema as Record<string, any>, indentation)
 		const optional = isRequired ? '' : '?'
 
-		interfaceCode += `\t${propName}${optional}: ${type}\n`
+		interfaceCode += `${indentation}${propName}${optional}: ${type}\n`
 	}
 
 	return interfaceCode

--- a/packages/rpc-plugin/src/utils/schema-utils.ts
+++ b/packages/rpc-plugin/src/utils/schema-utils.ts
@@ -22,6 +22,9 @@ export function mapJsonSchemaTypeToTypeScript(schema: Record<string, any>): stri
 		case 'object':
 			return `{\n${generateTypeScriptInterfaceProperties(schema)}}`
 		default:
+			if (schema?.$ref) {
+				return schema?.$ref.replace('#/definitions/', '')
+			}
 			return 'any'
 	}
 }


### PR DESCRIPTION
Hi @kerimovok,

This PR increases the client typescript interface generation coverage to include nested objects and adds nested Interfaces support.

My approach is:
* reuse the logic of generating interface properties when the property type is `object`
* Update `generateTypeScriptInterface()` usage to for loop on each schema definition instead of using only collected type name `generateTypeScriptInterface(typeName, schema)`
* properties that has `"$ref": "#/definitions/...."` will be used as is (without `#/definitions/`), assuming `ts-json-schema-generator` will always includes it in the definitions object which it does in my testing
* Update object map type testing to cover the new behavior

---

For example, in current behavior this response of type `Author`:

```ts
export interface Post {
  id: number;
  title: string;
  categories?: Category[];
}

export interface Category {
  id: number;
  title: string;
  tags: { id: number; name: string }[];
}

export interface Author {
  id: number;
  role: 'user' | 'admin';
  post: Post;
  postArray: Post[];
  category: Category;
  categoryArray: Category[];
  nestedObject: { isNestedObject: boolean, deepNested: { number: number } };
  nestedObjectArray: { isNestedObjectArray: boolean }[];
}
```

Will be outputted in the client as:

```ts
export interface Author {
	id: number
	role: 'user' | 'admin'
	post: any
	postArray: any[]
	category: any
	categoryArray: any[]
	nestedObject: Record<string, any>
	nestedObjectArray: Record<string, any>[]
}
```

With this PR, the outputted client will be:
```ts
export interface Author {
	id: number
	role: 'user' | 'admin'
	post: Post
	postArray: Post[]
	category: Category
	categoryArray: Category[]
	nestedObject: {
		isNestedObject: boolean
		deepNested: {
			number: number
		}
	}
	nestedObjectArray: {
		isNestedObjectArray: boolean
	}[]
}

export interface Post {
	id: number
	title: string
	categories?: Category[]
}

export interface Category {
	id: number
	title: string
	tags: {
		id: number
		name: string
	}[]
}
```

<br>
<br>

Couple of points to consider:
1. ~~the indentation of nested objects not yet updated~~
2. I see in the API Docs Plugin it has similar behavior of referencing nested schema types under `routes` but it's not included   under `schemas`

I would like to get your feedback first before adding more commits, hence I made this PR as a draft


Cheers,
Aziz

----

Edit 1: Update generated client interface after fixing nested indentation