### PR TITLE
feat(rpc-plugin): include response data in ApiError when available

### DIFF
--- a/packages/rpc-plugin/README.md
+++ b/packages/rpc-plugin/README.md
@@ -558,7 +558,7 @@ try {
 	})
 } catch (error) {
 	if (error instanceof ApiError) {
-		console.error(`API Error ${error.statusCode}: ${error.message}`)
+		console.error(`API Error ${error.statusCode}: ${error.message}`, error?.responseData)
 	} else {
 		console.error('Unexpected error:', error)
 	}

--- a/packages/rpc-plugin/src/generators/typescript-client.generator.ts
+++ b/packages/rpc-plugin/src/generators/typescript-client.generator.ts
@@ -67,10 +67,11 @@ export class TypeScriptClientGenerator implements RPCGenerator {
 /**
  * API Error class
  */
-export class ApiError extends Error {
+export class ApiError<ResponseData = any> extends Error {
 	constructor(
 		public statusCode: number,
-		message: string
+		message: string,
+		public responseData?: ResponseData
 	) {
 		super(message)
 		this.name = 'ApiError'
@@ -284,7 +285,7 @@ export class ApiClient {
 						: typeof responseData === 'string' && responseData.trim()
 							? responseData
 							: 'Request failed'
-				throw new ApiError(response.status, message)
+				throw new ApiError(response.status, message, responseData)
 			}
 
 			return responseData as T

--- a/packages/rpc-plugin/src/types/client.types.ts
+++ b/packages/rpc-plugin/src/types/client.types.ts
@@ -32,10 +32,11 @@ export type ResponseInterceptor = (response: Response) => Response | Promise<Res
 /**
  * API Error class
  */
-export class ApiError extends Error {
+export class ApiError<ResponseData = any> extends Error {
 	constructor(
 		public statusCode: number,
-		message: string
+		message: string,
+		public responseData?: ResponseData
 	) {
 		super(message)
 		this.name = 'ApiError'


### PR DESCRIPTION
Hi @kerimovok,

This PR exposes `responseData` (when available) in `ApiError` instance along with a generic to allow clients easier typing support.

I didn't add any extra option to customize exposing it since it's already extracted and available within `request` method

Cheers,
Aziz