### PR TITLE
fix(rpc-plugin): failed to execute 'fetch' on browser

### DIFF
--- a/packages/rpc-plugin/src/generators/typescript-client.generator.ts
+++ b/packages/rpc-plugin/src/generators/typescript-client.generator.ts
@@ -157,7 +157,7 @@ ${this.generateSchemaTypes(schemas)}
 export class ApiClient {
 	private baseUrl: string
 	private defaultHeaders: Record<string, string>
-	private fetchFn: FetchFunction
+	private fetchFn?: FetchFunction
 	private requestInterceptors: readonly RequestInterceptor[]
 	private responseInterceptors: readonly ResponseInterceptor[]
 
@@ -175,7 +175,7 @@ export class ApiClient {
 			'Content-Type': 'application/json',
 			...options.defaultHeaders
 		}
-		this.fetchFn = options.fetchFn || fetch
+		this.fetchFn = options.fetchFn
 		this.requestInterceptors = options.requestInterceptors || []
 		this.responseInterceptors = options.responseInterceptors || []
 	}
@@ -264,7 +264,7 @@ export class ApiClient {
 
 		try {
 			const interceptedRequest = await this.applyRequestInterceptors(url.toString(), requestOptions)
-			let response = await this.fetchFn(interceptedRequest.url, interceptedRequest.init)
+			let response = await (this.fetchFn || fetch)(interceptedRequest.url, interceptedRequest.init)
 			response = await this.applyResponseInterceptors(response)
 
 			if (response.status === 204 || response.headers.get('content-length') === '0') {


### PR DESCRIPTION
Hi @kerimovok,

This PR fixes default `fetch` missing its correct context when the client used on browser.


currently using the client on browser will throw an error `Failed to execute 'fetch' on 'Window': Illegal invocation`. 

<img width="959" height="183" alt="Screenshot 2026-03-30 at 1 29 51 PM" src="https://github.com/user-attachments/assets/eb5bda1f-9d70-4c77-9e74-107488f9521e" />


It could be fixed on client initialization by passing a wrapper function (example below) but that's not ideal

```js
new ApiClient('http://localhost:3000', {
  fetchFn: (...args) => fetch(...args),
})
```